### PR TITLE
ReferenceExplorer: Fix manual sorting through the tree view header bar

### DIFF
--- a/components/ReferenceExplorer/src/SearchFilterModelProxy.cpp
+++ b/components/ReferenceExplorer/src/SearchFilterModelProxy.cpp
@@ -106,11 +106,13 @@ bool SearchFilterModelProxy::filterAcceptsRow(
 
 bool SearchFilterModelProxy::lessThan(const QModelIndex &left,
                                       const QModelIndex &right) const {
-  auto left_location_role_var =
-      sourceModel()->data(left, IReferenceExplorerModel::LocationRole);
+  auto sort_role = sortRole();
+  if (sort_role != IReferenceExplorerModel::LocationRole) {
+    return QSortFilterProxyModel::lessThan(left, right);
+  }
 
-  auto right_location_role_var =
-      sourceModel()->data(right, IReferenceExplorerModel::LocationRole);
+  auto left_location_role_var = sourceModel()->data(left, sort_role);
+  auto right_location_role_var = sourceModel()->data(right, sort_role);
 
   std::optional<bool> opt_line_cmp_result;
   std::optional<bool> opt_column_cmp_result;


### PR DESCRIPTION
Use the default QSortFilterProxyModel::lessThan implementation when the sort role is not set to LocationRole.