### PR TITLE
ICodeView: Highlight line numbers of macro expansions

### DIFF
--- a/components/CodeView/include/multiplier/ui/ICodeModel.h
+++ b/components/CodeView/include/multiplier/ui/ICodeModel.h
@@ -59,7 +59,10 @@ class ICodeModel : public QAbstractItemModel {
     //! code previews, we hide the related entity ID, and return the token ID
     //! instead. But internal to the `CodeView`, we like to be able to access
     //! the real related entity ID so that we can highlight other uses.
-    RealRelatedEntityIdRole
+    RealRelatedEntityIdRole,
+
+    //! Returns true if this is part of a macro expansion
+    IsMacroExpansionRole,
   };
 
   //! Factory function

--- a/components/CodeView/src/CodeModel.cpp
+++ b/components/CodeView/src/CodeModel.cpp
@@ -234,6 +234,16 @@ QVariant CodeModel::data(const QModelIndex &index, int role) const {
           value.setValue(eid);
         }
         break;
+
+      case ICodeModel::IsMacroExpansionRole:
+        const auto &token = d->tokens.tokens[col->token_index];
+        const auto &variant = EntityId(token.derived_token().id()).Unpack();
+
+        auto is_macro_expansion =
+            std::holds_alternative<mx::MacroTokenId>(variant);
+
+        value.setValue(is_macro_expansion);
+        break;
     }
   }
 

--- a/components/CodeView/src/CodeView.h
+++ b/components/CodeView/src/CodeView.h
@@ -153,6 +153,9 @@ class CodeView final : public ICodeView {
 
     //! A block entry represents a single line in the QTextDocument object
     struct BlockEntry final {
+      //! True if this block entry contains macro expansion tokens
+      bool contains_macro_expansion{false};
+
       //! The list of token entries in this block
       std::vector<TokenEntry> token_entry_list;
 


### PR DESCRIPTION
![image](https://github.com/trailofbits/qt-multiplier/assets/5714290/ce5c9a2d-f541-49c8-8bf5-ef7d3a2f9400)
